### PR TITLE
Adding env to the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Firstly export the follwing vars:
 ```sh 
 export MEGAPORT_USERNAME=your-user-name
 export MEGAPORT_PASSWORD=your-password
-and 
+And: 
 export MEGAPORT_ENDPOINT=api.EndpointStaging #For Dev (Staging) 
-`OR`
+Or:
 export MEGAPORT_ENDPOINT=api.EndpointProduction # For Production
 ```
 To retrieve a new token for the megaport api and export it as a variable:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ is provided. To simplify the process of obtaining a new access token, there is a
 utility tool you can use. It is recommended that the token is provided via the
 `MEGAPORT_TOKEN` environment variable.
 
-Firstly export the follwing vars:
+Firstly, export the follwing vars:
 ```sh 
 export MEGAPORT_USERNAME=your-user-name
 export MEGAPORT_PASSWORD=your-password

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ is provided. To simplify the process of obtaining a new access token, there is a
 utility tool you can use. It is recommended that the token is provided via the
 `MEGAPORT_TOKEN` environment variable.
 
+Firstly export the follwing vars:
+```sh 
+export MEGAPORT_USERNAME=your-user-name
+export MEGAPORT_PASSWORD=your-password
+and 
+export MEGAPORT_ENDPOINT=api.EndpointStaging #For Dev (Staging) 
+`OR`
+export MEGAPORT_ENDPOINT=api.EndpointProduction # For Production
+```
 To retrieve a new token for the megaport api and export it as a variable:
 ```sh
 $ export $(make reset-token)


### PR DESCRIPTION
Adding 3 lines to the README. 
Lack of user and Pass is explicit on the code, but the prod environment is not.  
It can be found only here:
https://github.com/utilitywarehouse/terraform-provider-megaport/blob/f8002a65c61938c86e5a9689e015ffb8354f3f1b/megaport/api/client.go#L15-L16

Just a cosmetic change to save time of "first time users" 