### PR TITLE
Remove support for MCR v1

### DIFF
--- a/examples/megaport_mcr_basic/main.tf
+++ b/examples/megaport_mcr_basic/main.tf
@@ -1,10 +1,8 @@
 data "megaport_location" "foo" {
-  name_regex    = "{{ .location }}"
-  mcr_available = {{ .mcr_version }}
+  name_regex = "{{ .location }}"
 }
 
 resource "megaport_mcr" "foo" {
-  mcr_version = {{ .mcr_version }}
   name        = "terraform_acctest_{{ .uid }}"
   location_id = data.megaport_location.foo.id
   rate_limit  = {{ .rate_limit }}

--- a/examples/megaport_mcr_full/main.tf
+++ b/examples/megaport_mcr_full/main.tf
@@ -1,17 +1,12 @@
 data "megaport_location" "foo" {
-  name_regex    = "{{ .location }}"
-  mcr_available = {{ .mcr_version }}
+  name_regex = "{{ .location }}"
 }
 
 resource "megaport_mcr" "foo" {
-  mcr_version       = {{ .mcr_version }}
   name              = "terraform_acctest_{{ .uid }}"
   location_id       = data.megaport_location.foo.id
   rate_limit        = {{ .rate_limit }}
   invoice_reference = "{{ .uid }}"
-{{- if .term }}
-  term              = {{ .term }}
-{{- end }}
 {{- if .asn }}
   asn               = {{ .asn }}
 {{- end }}

--- a/megaport/api/mcr.go
+++ b/megaport/api/mcr.go
@@ -8,41 +8,6 @@ import (
 
 type McrCreateInput interface {
 	networkDesignInput
-	mcrVersion() uint64
-}
-
-type Mcr1CreateInput struct {
-	Asn              *uint64
-	InvoiceReference *string
-	LocationId       *uint64
-	Name             *string
-	RateLimit        *uint64
-	Term             *uint64
-}
-
-func (v *Mcr1CreateInput) mcrVersion() uint64 {
-	return 1
-}
-
-func (v *Mcr1CreateInput) productType() string {
-	return ProductTypeMcr1
-}
-
-func (v *Mcr1CreateInput) toPayload() ([]byte, error) {
-	payload := []*portCreatePayload{{
-		LocationId:  v.LocationId,
-		Config:      &portCreatePayloadPortConfig{},
-		CostCentre:  v.InvoiceReference,
-		PortSpeed:   v.RateLimit,
-		ProductName: v.Name,
-		ProductType: String(ProductTypeMcr1),
-		Term:        v.Term,
-		Virtual:     Bool(true),
-	}}
-	if v.Asn != nil && *v.Asn > 0 {
-		payload[0].Config.McrAsn = v.Asn
-	}
-	return json.Marshal(payload)
 }
 
 type Mcr2CreateInput struct {
@@ -51,10 +16,6 @@ type Mcr2CreateInput struct {
 	LocationId       *uint64
 	Name             *string
 	RateLimit        *uint64
-}
-
-func (v *Mcr2CreateInput) mcrVersion() uint64 {
-	return 2
 }
 
 func (v *Mcr2CreateInput) productType() string {

--- a/megaport/api/types.go
+++ b/megaport/api/types.go
@@ -152,18 +152,6 @@ type Product struct {
 	VxcAutoApproval bool
 }
 
-func (p *Product) McrVersion() int {
-	switch p.ProductType {
-	case "MCR2":
-		return 2
-	case "MEGAPORT":
-		if p.Virtual {
-			return 1
-		}
-	}
-	return -1
-}
-
 type ProductResources struct { // TODO: verify these are the only valid fields
 	// CrossConnect  ProductResourcesCrossConnect `json:"cross_connect"` // TODO: only referenced in https://dev.megaport.com/#general-get-product-list
 	Interface     ProductResourcesInterface

--- a/megaport/data_source_megaport_location.go
+++ b/megaport/data_source_megaport_location.go
@@ -26,12 +26,6 @@ func dataSourceMegaportLocation() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringIsValidRegExp,
 			},
-			"mcr_available": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntInSlice([]int{1, 2}),
-			},
 		},
 	}
 }
@@ -61,15 +55,6 @@ func dataSourceMegaportLocationRead(d *schema.ResourceData, m interface{}) error
 		nr := regexp.MustCompile(nameRegex.(string))
 		for _, loc := range megaportLocations {
 			if nr.MatchString(loc.Name) {
-				filtered = append(filtered, loc)
-			}
-		}
-	}
-	if mcrAvailable, ok := d.GetOk("mcr_available"); ok {
-		unfiltered := filtered
-		filtered = []*api.Location{}
-		for _, loc := range unfiltered {
-			if loc.Products.McrVersion == uint64(mcrAvailable.(int)) {
 				filtered = append(filtered, loc)
 			}
 		}

--- a/megaport/resource_megaport_mcr.go
+++ b/megaport/resource_megaport_mcr.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/utilitywarehouse/terraform-provider-megaport/megaport/api"
 )
 
@@ -22,12 +21,6 @@ func resourceMegaportMcr() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"mcr_version": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntInSlice([]int{1, 2}),
-			},
 			"location_id": {
 				Type:     schema.TypeInt,
 				Required: true,
@@ -41,13 +34,6 @@ func resourceMegaportMcr() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 				ForceNew: true,
-			},
-			"term": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      1,
-				ValidateFunc: validation.IntInSlice([]int{1, 12, 24, 36}),
 			},
 			"asn": {
 				Type:     schema.TypeInt,
@@ -71,12 +57,6 @@ func resourceMegaportMcrRead(d *schema.ResourceData, m interface{}) error {
 		d.SetId("")
 		return nil
 	}
-	if err := d.Set("mcr_version", p.McrVersion()); err != nil {
-		return err
-	}
-	if err := d.Set("term", int(p.ContractTermMonths)); err != nil {
-		return err
-	}
 	if err := d.Set("location_id", int(p.LocationId)); err != nil {
 		return err
 	}
@@ -97,25 +77,12 @@ func resourceMegaportMcrRead(d *schema.ResourceData, m interface{}) error {
 
 func resourceMegaportMcrCreate(d *schema.ResourceData, m interface{}) error {
 	cfg := m.(*Config)
-	var input api.McrCreateInput
-	switch d.Get("mcr_version").(int) {
-	case 1:
-		input = &api.Mcr1CreateInput{
-			LocationId:       api.Uint64FromInt(d.Get("location_id")),
-			Name:             api.String(d.Get("name")),
-			RateLimit:        api.Uint64FromInt(d.Get("rate_limit")),
-			Asn:              api.Uint64FromInt(d.Get("asn")),
-			Term:             api.Uint64FromInt(d.Get("term")),
-			InvoiceReference: api.String(d.Get("invoice_reference")),
-		}
-	case 2:
-		input = &api.Mcr2CreateInput{
-			LocationId:       api.Uint64FromInt(d.Get("location_id")),
-			Name:             api.String(d.Get("name")),
-			RateLimit:        api.Uint64FromInt(d.Get("rate_limit")),
-			Asn:              api.Uint64FromInt(d.Get("asn")),
-			InvoiceReference: api.String(d.Get("invoice_reference")),
-		}
+	input := &api.Mcr2CreateInput{
+		LocationId:       api.Uint64FromInt(d.Get("location_id")),
+		Name:             api.String(d.Get("name")),
+		RateLimit:        api.Uint64FromInt(d.Get("rate_limit")),
+		Asn:              api.Uint64FromInt(d.Get("asn")),
+		InvoiceReference: api.String(d.Get("invoice_reference")),
 	}
 	uid, err := cfg.Client.CreateMcr(input)
 	if err != nil {
@@ -130,20 +97,10 @@ func resourceMegaportMcrCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourceMegaportMcrUpdate(d *schema.ResourceData, m interface{}) error {
 	cfg := m.(*Config)
-	var input api.McrUpdateInput
-	switch d.Get("mcr_version").(int) {
-	case 1:
-		input = &api.Mcr1UpdateInput{
-			InvoiceReference: api.String(d.Get("invoice_reference")),
-			Name:             api.String(d.Get("name")),
-			ProductUid:       api.String(d.Id()),
-		}
-	case 2:
-		input = &api.Mcr2UpdateInput{
-			InvoiceReference: api.String(d.Get("invoice_reference")),
-			Name:             api.String(d.Get("name")),
-			ProductUid:       api.String(d.Id()),
-		}
+	input := &api.Mcr2UpdateInput{
+		InvoiceReference: api.String(d.Get("invoice_reference")),
+		Name:             api.String(d.Get("name")),
+		ProductUid:       api.String(d.Id()),
 	}
 	if err := cfg.Client.UpdateMcr(input); err != nil {
 		return err

--- a/megaport/resource_megaport_mcr_test.go
+++ b/megaport/resource_megaport_mcr_test.go
@@ -43,112 +43,13 @@ func init() {
 	})
 }
 
-func TestAccMegaportMcr1_basic(t *testing.T) {
-	var mcr, mcrUpdated, mcrNew api.Product
-	rName := "t" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	configValues := map[string]interface{}{
-		"uid":         rName,
-		"mcr_version": 1,
-		"location":    "Digital Realty LHR20", // mcr1
-		"rate_limit":  100,
-	}
-	cfg, err := newTestAccConfig("megaport_mcr_basic", configValues, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cfgUpdate, err := newTestAccConfig("megaport_mcr_full", configValues, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rAsn := 1 + acctest.RandIntRange(0, math.MaxInt32)
-	configValuesNew := mergeMaps(configValues, map[string]interface{}{
-		"asn":        rAsn,
-		"term":       12,
-		"rate_limit": 500,
-	})
-	cfgForceNew, err := newTestAccConfig("megaport_mcr_full", configValuesNew, 2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckResourceDestroy,
-		Steps: []resource.TestStep{
-			{
-				PreConfig: func() { cfg.log() },
-				Config:    cfg.Config,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceExists("megaport_mcr.foo", &mcr),
-					resource.TestCheckResourceAttr("megaport_mcr.foo", "name", "terraform_acctest_"+rName),
-					resource.TestCheckResourceAttr("megaport_mcr.foo", "rate_limit", "100"),
-					resource.TestCheckResourceAttrSet("megaport_mcr.foo", "asn"),
-					resource.TestCheckResourceAttrPair("megaport_mcr.foo", "location_id", "data.megaport_location.foo", "id"),
-					resource.TestCheckResourceAttr("megaport_mcr.foo", "term", "1"),
-					resource.TestCheckResourceAttr("megaport_mcr.foo", "invoice_reference", ""),
-				),
-			},
-			{
-				ResourceName:      "megaport_mcr.foo",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				PreConfig: func() { cfgUpdate.log() },
-				Config:    cfgUpdate.Config,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceExists("megaport_mcr.foo", &mcrUpdated),
-					resource.TestCheckResourceAttr("megaport_mcr.foo", "name", "terraform_acctest_"+rName),
-					resource.TestCheckResourceAttr("megaport_mcr.foo", "rate_limit", "100"),
-					resource.TestCheckResourceAttrSet("megaport_mcr.foo", "asn"),
-					resource.TestCheckResourceAttrPair("megaport_mcr.foo", "location_id", "data.megaport_location.foo", "id"),
-					resource.TestCheckResourceAttr("megaport_mcr.foo", "term", "1"),
-					resource.TestCheckResourceAttr("megaport_mcr.foo", "invoice_reference", rName),
-				),
-			},
-			{
-				ResourceName:      "megaport_mcr.foo",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				PreConfig: func() { cfgForceNew.log() },
-				Config:    cfgForceNew.Config,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceExists("megaport_mcr.foo", &mcrNew),
-					resource.TestCheckResourceAttr("megaport_mcr.foo", "name", "terraform_acctest_"+rName),
-					resource.TestCheckResourceAttr("megaport_mcr.foo", "rate_limit", "500"),
-					resource.TestCheckResourceAttr("megaport_mcr.foo", "asn", strconv.FormatUint(uint64(rAsn), 10)),
-					resource.TestCheckResourceAttrPair("megaport_mcr.foo", "location_id", "data.megaport_location.foo", "id"),
-					resource.TestCheckResourceAttr("megaport_mcr.foo", "term", "12"),
-					resource.TestCheckResourceAttr("megaport_mcr.foo", "invoice_reference", rName),
-				),
-			},
-			{
-				ResourceName:      "megaport_mcr.foo",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-
-	if mcr.ProductUid != mcrUpdated.ProductUid {
-		t.Errorf("TestAccMegaportMcr_basic: expected the MCR to be updated but the resource ids differ")
-	}
-	if mcr.ProductUid == mcrNew.ProductUid {
-		t.Errorf("TestAccMegaportMcr_basic: expected the MCR to be recreated but the resource ids are identical")
-	}
-}
-
 func TestAccMegaportMcr2_basic(t *testing.T) {
 	var mcr, mcrUpdated, mcrNew api.Product
 	rName := "t" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	configValues := map[string]interface{}{
-		"uid":         rName,
-		"mcr_version": 2,
-		"location":    "Global Switch London East",
-		"rate_limit":  1000,
+		"uid":        rName,
+		"location":   "Global Switch London East",
+		"rate_limit": 1000,
 	}
 	cfg, err := newTestAccConfig("megaport_mcr_basic", configValues, 0)
 	if err != nil {

--- a/website/docs/d/location.html.md
+++ b/website/docs/d/location.html.md
@@ -26,9 +26,6 @@ The following arguments are supported:
 * `name_regex` - (Required, Forces new resource) A regex string filter to apply
 to the location list returned by Megaport.
 
-* `mcr_available` - (Optional, Forces new resource) Filter locations where the
-specified MCR version is available (accepted values are `1` and `2`).
-
 ~> **Note:** If more or less than a single match is returned by the search,
 Terraform will fail. Ensure that your search is specific enough to return a
 single location.

--- a/website/docs/r/mcr.html.md
+++ b/website/docs/r/mcr.html.md
@@ -15,12 +15,10 @@ updated and deleted.
 
 ```hcl
 data "megaport_location" "foo" {
-  name_regex    = "foobar"
-  mcr_available = 2
+  name_regex = "foobar"
 }
 
 resource "megaport_mcr" "foo" {
-  mcr_version = 2
   name        = "foo"
   location_id = data.megaport_location.foo.id
   speed       = 1000
@@ -34,16 +32,11 @@ The following arguments are supported:
 * `location_id` - (Required, Forces new resource) The numeric id of the location
 where this MCR should be created in.
 * `name` - (Required) The name of the MCR.
-* `mcr_version` - (Required, Forces new resource) Determines whether this is a
-MCR 1.x or an MCR 2.0 (accepted values: `1` and `2`).
-* `rate_limit` - (Required, Forces new resource) The speed of the MCR. Available
-speeds depend on the version of the MCR. Please check with the Megaport
-documentation for more detail.
+* `rate_limit` - (Required, Forces new resource) The speed of the MCR. Please
+check with the Megaport documentation for available speeds.
 * `asn` - (Optional, Forces new resource) The Autonomous System Number (ASN) to
 use for BGP peering sessions on VXCs connected to this MCR. If not configured,
 the Megaport supplied public ASN will be used.
-* `term` - (Optional, Forces new resource, Default: `1`) Length of the contract (`1`, `12`,
-`24` or `36` months). Only applicable to MCR 1.x.
 * `invoice_reference` - (Optional) Used for billing purposes, a reference to
 this specific line item.
 


### PR DESCRIPTION
Version 1 of the Megaport Cloud Router is deprecated and will be removed in November.